### PR TITLE
Support bzip2 archives as well as gzip ones

### DIFF
--- a/conans/tools.py
+++ b/conans/tools.py
@@ -44,7 +44,7 @@ def human_size(size_bytes):
 
 
 def unzip(filename, destination="."):
-    if ".tar.gz" in filename or ".tgz" in filename:
+    if ".tar.gz" in filename or ".tgz" in filename or "tzb2" in filename or "tar.bz2" in filename:
         return untargz(filename, destination)
     import zipfile
     full_path = os.path.normpath(os.path.join(os.getcwd(), destination))
@@ -66,7 +66,7 @@ def unzip(filename, destination="."):
 
 def untargz(filename, destination="."):
     import tarfile
-    with tarfile.TarFile.open(filename, 'r:gz') as tarredgzippedFile:
+    with tarfile.TarFile.open(filename, 'r:*') as tarredgzippedFile:
         tarredgzippedFile.extractall(destination)
 
 


### PR DESCRIPTION
Python already supports detecting the zip format by
open the tarfile with r_. This just changes r:gz to r:_
and adds extra checks for tar.bz2 and tbz2.
